### PR TITLE
Updated frontmatter to get out of the way and use all Griffe's options

### DIFF
--- a/docs/user-guide/frontmatter-reference.md
+++ b/docs/user-guide/frontmatter-reference.md
@@ -145,26 +145,71 @@ processors:
     scan_comments: false
 ```
 
-### `griffe_options`
+### `griffe`
 
 **Type**: `object`  
 **Default**: `{}`
 
-Options passed directly to Griffe for code parsing.
+Griffe configuration with loader options and method calls. This structure mirrors Griffe's API directly.
 
 ```yaml
-griffe_options:
-  include_private: false
-  show_source: true
-  docstring_style: "google"
-  follow_imports: true
+griffe:
+  loader:
+    # GriffeLoader init options
+    allow_inspection: true
+    store_source: false
+    docstring_parser: "google"
+    
+    # Method calls on the loader
+    load:
+      submodules: true
+      find_stubs_package: false
+    resolve_aliases:
+      external: false
+      implicit: false
+      max_iterations: 10
 ```
 
-Common options:
-- `include_private`: Include private members (leading underscore)
-- `show_source`: Include source code in parsed objects
-- `docstring_style`: Docstring parsing style (`"google"`, `"numpy"`, `"sphinx"`)
-- `follow_imports`: Parse imported modules
+**Structure**:
+- `loader`: Configuration for the GriffeLoader instance
+  - Top-level keys are passed to `GriffeLoader.__init__()`
+  - Nested objects represent method calls on the loader
+  
+**Common loader init options**:
+- `allow_inspection`: Allow runtime introspection (default: `true`)
+- `store_source`: Store source code in parsed objects (default: `true`)
+- `docstring_parser`: Docstring parsing style (`"google"`, `"numpy"`, `"sphinx"`)
+
+**Common method calls**:
+- `load`: Options for `loader.load()` method
+  - `submodules`: Recurse into submodules (default: `true`)
+  - `find_stubs_package`: Search for stubs-only packages (default: `false`)
+- `resolve_aliases`: Options for `loader.resolve_aliases()` method
+  - `external`: Load external packages during resolution (default: `null`)
+  - `implicit`: Resolve implicit aliases (default: `false`)
+  - `max_iterations`: Maximum resolution iterations (default: `null`)
+
+**Examples**:
+
+Disable alias resolution (fixes standard library import issues):
+```yaml
+griffe:
+  loader:
+    allow_inspection: true
+    load:
+      submodules: false
+    # Note: no resolve_aliases call = no alias resolution
+```
+
+Enable strict alias resolution:
+```yaml
+griffe:
+  loader:
+    allow_inspection: false
+    resolve_aliases:
+      external: true
+      implicit: true
+```
 
 ## Output configuration
 

--- a/src/griffonner/core.py
+++ b/src/griffonner/core.py
@@ -77,7 +77,7 @@ def generate_file(
             logger.info(f"Loading Griffe object for: {output_item.griffe_target}")
             griffe_obj = load_griffe_object(
                 output_item.griffe_target,
-                griffe_options=parsed.frontmatter.griffe_options,
+                griffe_config=parsed.frontmatter.griffe,
             )
 
             # Prepare initial template context

--- a/src/griffonner/frontmatter.py
+++ b/src/griffonner/frontmatter.py
@@ -32,7 +32,7 @@ class FrontmatterConfig(BaseModel):
 
     template: str
     output: List[OutputItem]
-    griffe_options: Dict[str, Any] = Field(default_factory=dict)
+    griffe: Dict[str, Any] = Field(default_factory=dict)
     custom_vars: Dict[str, Any] = Field(default_factory=dict)
     processors: Optional[ProcessorConfig] = Field(default=None)
 

--- a/src/griffonner/griffe_wrapper.py
+++ b/src/griffonner/griffe_wrapper.py
@@ -23,14 +23,14 @@ class ModuleLoadError(GriffeError):
 def load_griffe_object(
     target: str,
     search_paths: Optional[List[Path]] = None,
-    griffe_options: Optional[Dict[str, Any]] = None,
+    griffe_config: Optional[Dict[str, Any]] = None,
 ) -> Union[GriffeObject, Alias]:
-    """Load a Griffe object from module name.
+    """Load a Griffe object using flexible configuration.
 
     Args:
         target: Module name (e.g., 'mypackage.utils', 'os', 'pathlib')
         search_paths: Additional paths to search for modules
-        griffe_options: Options to pass to Griffe loader
+        griffe_config: Griffe configuration with loader options and method calls
 
     Returns:
         Raw Griffe object
@@ -40,12 +40,12 @@ def load_griffe_object(
     """
     if search_paths is None:
         search_paths = []
-    if griffe_options is None:
-        griffe_options = {}
+    if griffe_config is None:
+        griffe_config = {}
 
     logger.info(f"Loading Griffe object for target: {target}")
     logger.info(f"Search paths provided: {search_paths}")
-    logger.info(f"Griffe options: {griffe_options}")
+    logger.info(f"Griffe config: {griffe_config}")
 
     # Add current working directory and src to search paths
     default_paths = [Path.cwd(), Path.cwd() / "src"]
@@ -66,18 +66,50 @@ def load_griffe_object(
     logger.info(f"Added {len(python_paths_added)} paths to sys.path")
 
     try:
-        logger.info("Creating GriffeLoader instance")
+        # Extract loader configuration
+        loader_config = griffe_config.get("loader", {})
+
+        # Separate loader init kwargs from method calls
+        loader_kwargs = {}
+        method_calls = {}
+
+        for key, value in loader_config.items():
+            if isinstance(value, dict):
+                # This is a method call configuration
+                method_calls[key] = value
+            else:
+                # This is a loader init kwarg
+                loader_kwargs[key] = value
+
+        logger.info(f"Loader kwargs: {loader_kwargs}")
+        logger.info(f"Method calls: {list(method_calls.keys())}")
+
+        # Create GriffeLoader instance
         loader = griffe.GriffeLoader(
             search_paths=all_search_paths,
-            **griffe_options,
+            **loader_kwargs,
         )
 
-        logger.info(f"Loading target '{target}' with Griffe")
-        griffe_obj = loader.load(target)
+        # Execute the main load call
+        load_kwargs = method_calls.get("load", {})
+        logger.info(f"Loading target '{target}' with kwargs: {load_kwargs}")
+        griffe_obj = loader.load(target, **load_kwargs)
 
         if griffe_obj is None:
             logger.error(f"Griffe returned None for target '{target}'")
             raise ModuleLoadError(f"Target '{target}' not found")
+
+        # Execute any other method calls on the loader
+        for method_name, method_kwargs in method_calls.items():
+            if method_name == "load":
+                continue  # Already handled above
+
+            if hasattr(loader, method_name):
+                logger.info(f"Calling loader.{method_name}({method_kwargs})")
+                result = getattr(loader, method_name)(**method_kwargs)
+                logger.info(f"Method {method_name} returned: {result}")
+            else:
+                logger.warning(f"Loader has no method '{method_name}', skipping")
 
         logger.info(f"Successfully loaded Griffe object: {type(griffe_obj).__name__}")
         logger.info(f"Object name: {getattr(griffe_obj, 'name', 'unknown')}")

--- a/test/test_frontmatter.py
+++ b/test/test_frontmatter.py
@@ -58,30 +58,32 @@ class TestFrontmatterConfig:
         )
         assert config.template == "python/default/module.j2"
 
-    def test_griffe_options_dict(self):
-        """Tests that griffe_options accepts arbitrary dict values."""
+    def test_griffe_config_dict(self):
+        """Tests that griffe accepts arbitrary nested configuration."""
         config = FrontmatterConfig(
             template="python/default/module.md.jinja2",
             output=[OutputItem(filename="test.md", griffe_target="mymodule")],
-            griffe_options={
-                "include_private": False,
-                "follow_imports": True,
-                "docstring_style": "sphinx",
-                "custom_option": "custom_value",
+            griffe={
+                "loader": {
+                    "include_private": False,
+                    "store_source": True,
+                    "load": {"submodules": True},
+                    "resolve_aliases": {"external": False},
+                }
             },
         )
-        assert config.griffe_options["include_private"] is False
-        assert config.griffe_options["follow_imports"] is True
-        assert config.griffe_options["docstring_style"] == "sphinx"
-        assert config.griffe_options["custom_option"] == "custom_value"
+        assert config.griffe["loader"]["include_private"] is False
+        assert config.griffe["loader"]["store_source"] is True
+        assert config.griffe["loader"]["load"]["submodules"] is True
+        assert config.griffe["loader"]["resolve_aliases"]["external"] is False
 
-    def test_griffe_options_default_empty(self):
-        """Tests that griffe_options defaults to empty dict."""
+    def test_griffe_config_default_empty(self):
+        """Tests that griffe defaults to empty dict."""
         config = FrontmatterConfig(
             template="python/default/module.md.jinja2",
             output=[OutputItem(filename="test.md", griffe_target="mymodule")],
         )
-        assert config.griffe_options == {}
+        assert config.griffe == {}
 
 
 class TestParseFrontmatterFile:


### PR DESCRIPTION
Frontmatter was preventing certain options from being used. Generises so you can configure the loader in loads of different ways. Closes #16 