### PR TITLE
Passed through source files without frontmatter

### DIFF
--- a/docs/home/index.md
+++ b/docs/home/index.md
@@ -189,7 +189,7 @@ griffonner watch docs/pages/ --output docs/generated
 griffonner watch docs/pages/ --template-dir custom-templates/
 ```
 
-When files with frontmatter are modified, Griffonner automatically regenerates the corresponding output files.
+When files are modified, Griffonner automatically processes them - regenerating output files for those with frontmatter and copying files without frontmatter directly.
 
 ### Template discovery
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,7 +189,7 @@ griffonner watch docs/pages/ --output docs/generated
 griffonner watch docs/pages/ --template-dir custom-templates/
 ```
 
-When files with frontmatter are modified, Griffonner automatically regenerates the corresponding output files.
+When files are modified, Griffonner automatically processes them - regenerating output files for those with frontmatter and copying files without frontmatter directly.
 
 ### Template discovery
 

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -14,7 +14,7 @@ Griffonner is a template-first Python documentation generator that gets out of y
 
 ### `generate`
 
-Generate documentation from source files with frontmatter.
+Generate documentation from source files. Files with frontmatter are processed using templates, while files without frontmatter are copied directly to the output (passthrough).
 
 ```
 griffonner generate [OPTIONS] SOURCE
@@ -22,7 +22,7 @@ griffonner generate [OPTIONS] SOURCE
 
 **Arguments:**
 
-- `SOURCE` - Source file or directory containing files with frontmatter
+- `SOURCE` - Source file or directory containing files (with or without frontmatter)
 
 **Options:**
 
@@ -89,7 +89,7 @@ griffonner watch docs/pages/ --local-plugins myproject.docs_plugins
 **Behaviour:**
 
 - Monitors all files in the source directory for changes
-- Only regenerates files that contain valid frontmatter
+- Processes files with frontmatter using templates, copies files without frontmatter directly (passthrough)
 - Automatically creates output directories if they don't exist
 - Shows real-time feedback when files are regenerated
 - Stops with Ctrl+C
@@ -344,8 +344,8 @@ griffonner watch docs/pages/ --verbose
 
 ### Performance
 
-- Watch mode monitors all file types but only processes files with valid frontmatter
-- Only files with valid frontmatter are processed
+- Watch mode monitors all file types and processes both frontmatter and regular files
+- Files with frontmatter are generated using templates, files without are copied directly
 - Generation is incremental - only changed files are regenerated in watch mode
 
 ### Workflow

--- a/docs/user-guide/watch-mode.md
+++ b/docs/user-guide/watch-mode.md
@@ -53,10 +53,10 @@ Watch mode monitors:
 
 - **File types**: `.md` and `.markdown` files only
 - **Scope**: All files recursively in the source directory
-- **Filtering**: Only processes files with valid frontmatter
+- **Processing**: Files with frontmatter are generated using templates, files without frontmatter are copied directly to output (passthrough)
 - **Events**: File modifications and new file creation
 
-Files without frontmatter are ignored, so you can have regular markdown files alongside Griffonner source files.
+All files are processed - those with frontmatter generate documentation using templates, while regular files are copied directly to maintain your complete documentation structure.
 
 ## Development workflow
 
@@ -220,7 +220,7 @@ Watch mode uses Python's `watchdog` library for efficient file monitoring:
 
 For projects with many files:
 
-- Only files with frontmatter are processed
+- Files with frontmatter are generated using templates, files without are copied directly
 - Generation is incremental (only changed files)
 - Template loading is cached between runs
 

--- a/src/griffonner/core.py
+++ b/src/griffonner/core.py
@@ -1,11 +1,11 @@
 """Main generation logic for Griffonner."""
 
 import logging
-import textwrap
+import shutil
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
-from .frontmatter import find_frontmatter_files, parse_frontmatter_file
+from .frontmatter import parse_frontmatter_file
 from .griffe_wrapper import load_griffe_object
 from .plugins.manager import PluginManager
 from .templates import TemplateLoader
@@ -15,6 +15,127 @@ logger = logging.getLogger("griffonner.core")
 
 class GenerationError(Exception):
     """Base exception for generation errors."""
+
+
+def find_all_files(directory: Path) -> List[Path]:
+    """Find all files in a directory recursively.
+
+    Args:
+        directory: Directory to search
+
+    Returns:
+        List of all file paths
+
+    Raises:
+        NotADirectoryError: If directory doesn't exist or isn't a directory
+    """
+    logger.info(f"Finding all files in: {directory}")
+
+    if not directory.exists():
+        logger.error(f"Directory not found: {directory}")
+        raise NotADirectoryError(f"Directory not found: {directory}")
+
+    if not directory.is_dir():
+        logger.error(f"Path is not a directory: {directory}")
+        raise NotADirectoryError(f"Path is not a directory: {directory}")
+
+    all_files = []
+    skipped_files = []
+
+    for file_path in directory.rglob("*"):
+        if not file_path.is_file():
+            continue
+        try:
+            # Quick check that file is readable
+            file_path.read_text(encoding="utf-8", errors="strict")
+            all_files.append(file_path)
+            logger.info(f"Found file: {file_path}")
+        except (UnicodeDecodeError, PermissionError, OSError) as e:
+            logger.warning(f"Skipping unreadable file {file_path}: {e}")
+            skipped_files.append(file_path)
+            continue
+
+    logger.info(f"Found {len(all_files)} files, {len(skipped_files)} skipped")
+    return sorted(all_files)
+
+
+def categorize_files(files: List[Path]) -> Tuple[List[Path], List[Path]]:
+    """Categorize files into frontmatter files and passthrough files.
+
+    Args:
+        files: List of file paths to categorize
+
+    Returns:
+        Tuple of (frontmatter_files, passthrough_files)
+    """
+    logger.info(f"Categorizing {len(files)} files")
+
+    frontmatter_files = []
+    passthrough_files = []
+
+    for file_path in files:
+        try:
+            content = file_path.read_text(encoding="utf-8")
+            if content.startswith("---\n"):
+                frontmatter_files.append(file_path)
+                logger.info(f"Frontmatter file: {file_path}")
+            else:
+                passthrough_files.append(file_path)
+                logger.info(f"Passthrough file: {file_path}")
+        except (UnicodeDecodeError, PermissionError, OSError) as e:
+            logger.warning(f"Error reading {file_path}, treating as passthrough: {e}")
+            passthrough_files.append(file_path)
+
+    logger.info(
+        f"Categorized: {len(frontmatter_files)} frontmatter, "
+        f"{len(passthrough_files)} passthrough"
+    )
+    return frontmatter_files, passthrough_files
+
+
+def copy_file_passthrough(
+    source_file: Path, source_dir: Path, output_dir: Path
+) -> Path:
+    """Copy a file from source to output preserving directory structure.
+
+    Args:
+        source_file: Source file path
+        source_dir: Base source directory
+        output_dir: Base output directory
+
+    Returns:
+        Path to the copied output file
+
+    Raises:
+        GenerationError: If copy fails
+    """
+    logger.info(f"Copying passthrough file: {source_file}")
+
+    # Calculate relative path from source_dir to source_file
+    try:
+        relative_path = source_file.relative_to(source_dir)
+    except ValueError as e:
+        raise GenerationError(
+            f"Source file {source_file} is not within source directory {source_dir}"
+        ) from e
+
+    # Calculate target output file path
+    output_file = output_dir / relative_path
+    logger.info(f"Target output path: {output_file}")
+
+    # Create parent directories if needed
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Copy the file
+        shutil.copy2(source_file, output_file)
+        logger.info(f"Successfully copied: {source_file} -> {output_file}")
+        return output_file
+    except (OSError, IOError) as e:
+        logger.exception(f"Failed to copy {source_file} to {output_file}")
+        raise GenerationError(
+            f"Failed to copy {source_file} to {output_file}: {e}"
+        ) from e
 
 
 def generate_file(
@@ -158,13 +279,13 @@ def generate_directory(
     """Generate documentation from all files in a directory.
 
     Args:
-        pages_dir: Directory containing source files with frontmatter
+        pages_dir: Directory containing source files (with or without frontmatter)
         output_dir: Base output directory
         template_dirs: Additional template search directories
         plugin_manager: Optional plugin manager for processors/filters
 
     Returns:
-        List of all generated output file paths
+        List of all generated and copied output file paths
 
     Raises:
         GenerationError: If generation fails
@@ -172,53 +293,80 @@ def generate_directory(
     logger.info(f"Generating documentation from directory: {pages_dir}")
     logger.info(f"Output directory: {output_dir}")
 
-    # Find all frontmatter files
-    logger.info("Searching for frontmatter files")
-    source_files = find_frontmatter_files(pages_dir)
-    logger.info(f"Found {len(source_files)} frontmatter files")
+    # Find all files
+    logger.info("Searching for all files")
+    all_files = find_all_files(pages_dir)
+    logger.info(f"Found {len(all_files)} total files")
 
-    if not source_files:
-        logger.error(f"No frontmatter files found in {pages_dir}")
-        error_msg = textwrap.dedent(f"""\
-            No frontmatter files found in {pages_dir}
+    if not all_files:
+        logger.warning(f"No files found in {pages_dir}")
+        return []
 
-            Looking for files that start with:
-            ---
-            template: "python/default/module.md.jinja2"
-            output:
-              filename: "api.md"
-              griffe_target: "mypackage.module"
-            ---""")
-        raise GenerationError(error_msg)
+    # Categorize files into frontmatter and passthrough
+    logger.info("Categorizing files")
+    frontmatter_files, passthrough_files = categorize_files(all_files)
+    logger.info(
+        f"Files: {len(frontmatter_files)} frontmatter, "
+        f"{len(passthrough_files)} passthrough"
+    )
 
-    all_generated = []
+    all_output_files = []
     errors = []
 
-    # Generate each file, collecting errors
-    logger.info(f"Processing {len(source_files)} source files")
-    for i, source_file in enumerate(source_files):
-        logger.info(f"Processing file {i+1}/{len(source_files)}: {source_file}")
-        try:
-            generated = generate_file(
-                source_file, output_dir, template_dirs, plugin_manager
+    # Process frontmatter files (generate using templates)
+    if frontmatter_files:
+        logger.info(f"Processing {len(frontmatter_files)} frontmatter files")
+        for i, source_file in enumerate(frontmatter_files):
+            logger.info(
+                f"Processing frontmatter file {i+1}/{len(frontmatter_files)}: "
+                f"{source_file}"
             )
-            all_generated.extend(generated)
-            logger.info(f"Processed {source_file}: {len(generated)} files generated")
-        except Exception as e:
-            logger.exception(f"Failed to process {source_file}")
-            errors.append(f"Failed to generate {source_file}: {e}")
+            try:
+                generated = generate_file(
+                    source_file, output_dir, template_dirs, plugin_manager
+                )
+                all_output_files.extend(generated)
+                logger.info(f"Generated {len(generated)} files from {source_file}")
+            except Exception as e:
+                logger.exception(f"Failed to process frontmatter file {source_file}")
+                errors.append(f"Failed to generate {source_file}: {e}")
+
+    # Process passthrough files (copy directly)
+    if passthrough_files:
+        logger.info(f"Processing {len(passthrough_files)} passthrough files")
+        for i, source_file in enumerate(passthrough_files):
+            logger.info(
+                f"Processing passthrough file {i+1}/{len(passthrough_files)}: "
+                f"{source_file}"
+            )
+            try:
+                copied_file = copy_file_passthrough(source_file, pages_dir, output_dir)
+                all_output_files.append(copied_file)
+                logger.info(f"Copied passthrough file: {source_file} -> {copied_file}")
+            except Exception as e:
+                logger.exception(f"Failed to copy passthrough file {source_file}")
+                errors.append(f"Failed to copy {source_file}: {e}")
 
     # If there were errors, include summary
     if errors:
-        logger.error(f"Directory generation completed with {len(errors)} errors")
-        error_parts = [f"Generation completed with {len(errors)} errors:"]
+        logger.error(f"Directory processing completed with {len(errors)} errors")
+        error_parts = [f"Processing completed with {len(errors)} errors:"]
         error_parts.extend(f"  - {err}" for err in errors)
         error_msg = "\n".join(error_parts)
         raise GenerationError(error_msg)
 
-    generated_count = len(all_generated)
-    logger.info(f"Directory generation completed: {generated_count} total files")
-    return all_generated
+    output_count = len(all_output_files)
+    logger.info(f"Directory processing completed: {output_count} total output files")
+    generated_count = len(
+        [
+            f
+            for f in all_output_files
+            if any(str(f).endswith(ext) for ext in [".md", ".html", ".rst"])
+        ]
+    )
+    logger.info(f"  - Generated: {generated_count}")
+    logger.info(f"  - Copied: {len(passthrough_files)}")
+    return all_output_files
 
 
 def generate(

--- a/src/griffonner/watcher.py
+++ b/src/griffonner/watcher.py
@@ -9,8 +9,7 @@ import typer
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
-from .core import generate_file
-from .frontmatter import find_frontmatter_files
+from .core import categorize_files, copy_file_passthrough, generate_file
 
 if TYPE_CHECKING:
     from .plugins.manager import PluginManager
@@ -63,7 +62,7 @@ class GriffonnerEventHandler(FileSystemEventHandler):
         file_path = Path(str(event.src_path))
         logger.info(f"File modified: {file_path}")
 
-        # Process all files that might have frontmatter
+        # Process all files (frontmatter and passthrough)
         logger.info(f"Processing file modification: {file_path}")
         self._regenerate_file(file_path)
 
@@ -82,7 +81,7 @@ class GriffonnerEventHandler(FileSystemEventHandler):
         file_path = Path(str(event.src_path))
         logger.info(f"File created: {file_path}")
 
-        # Process all files that might have frontmatter
+        # Process all files (frontmatter and passthrough)
         logger.info(f"Processing file creation: {file_path}")
         self._regenerate_file(file_path)
 
@@ -92,42 +91,62 @@ class GriffonnerEventHandler(FileSystemEventHandler):
         Args:
             file_path: Path to the file that changed
         """
-        logger.info(f"Attempting to regenerate file: {file_path}")
+        logger.info(f"Attempting to process file: {file_path}")
 
         try:
-            # Check if file is within our source directory and has frontmatter
+            # Check if file is within our source directory
             logger.info("Checking if file is within source directory")
             relative_path = file_path.relative_to(self.source_dir)
             logger.info(f"File relative path: {relative_path}")
 
-            # Verify the file has frontmatter by checking if it's in our list
-            logger.info("Checking for frontmatter files in source directory")
-            frontmatter_files = find_frontmatter_files(self.source_dir)
-            if file_path not in frontmatter_files:
-                logger.info("File not in frontmatter files list, ignoring")
-                return  # Not a frontmatter file, ignore
+            # Check if file is readable (skip if not)
+            try:
+                file_path.read_text(encoding="utf-8", errors="strict")
+            except (UnicodeDecodeError, PermissionError, OSError) as e:
+                logger.warning(f"Skipping unreadable file {file_path}: {e}")
+                return
 
-            logger.info("File confirmed as frontmatter file, proceeding")
-            # Generate the file
-            generated_files = generate_file(
-                file_path, self.output_dir, self.template_dirs, self.plugin_manager
-            )
+            # Categorize the file
+            logger.info("Categorizing file type")
+            frontmatter_files, passthrough_files = categorize_files([file_path])
 
-            file_count = len(generated_files)
-            typer.echo(f"🔄 Regenerated {file_count} files from {relative_path}:")
-            for generated_file in generated_files:
-                rel_generated = generated_file.relative_to(self.output_dir)
-                typer.echo(f"  📄 {rel_generated}")
+            if frontmatter_files:
+                # File has frontmatter - generate using templates
+                logger.info("File confirmed as frontmatter file, generating")
+                generated_files = generate_file(
+                    file_path, self.output_dir, self.template_dirs, self.plugin_manager
+                )
 
-            logger.info(f"File regeneration successful: {file_count} files generated")
+                file_count = len(generated_files)
+                typer.echo(f"🔄 Regenerated {file_count} files from {relative_path}:")
+                for generated_file in generated_files:
+                    rel_generated = generated_file.relative_to(self.output_dir)
+                    typer.echo(f"  📄 {rel_generated}")
+
+                logger.info(f"File generation successful: {file_count} files generated")
+
+            elif passthrough_files:
+                # File is passthrough - copy directly
+                logger.info("File confirmed as passthrough file, copying")
+                copied_file = copy_file_passthrough(
+                    file_path, self.source_dir, self.output_dir
+                )
+
+                rel_copied = copied_file.relative_to(self.output_dir)
+                typer.echo(f"🔄 Copied passthrough file {relative_path}:")
+                typer.echo(f"  📄 {rel_copied}")
+
+                logger.info(f"File copy successful: {file_path} -> {copied_file}")
+            else:
+                logger.warning(f"File {file_path} could not be categorized, ignoring")
 
         except ValueError as e:
             # File is not within source directory, ignore
             logger.info(f"File not within source directory, ignoring ({e})")
             return
         except Exception as e:
-            logger.exception(f"File regeneration failed for {file_path}")
-            typer.echo(f"❌ Failed to regenerate {file_path}: {e}", err=True)
+            logger.exception(f"File processing failed for {file_path}")
+            typer.echo(f"❌ Failed to process {file_path}: {e}", err=True)
 
 
 class DocumentationWatcher:

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7,6 +7,9 @@ import pytest
 
 from griffonner.core import (
     GenerationError,
+    categorize_files,
+    copy_file_passthrough,
+    find_all_files,
     generate,
     generate_directory,
     generate_file,
@@ -234,7 +237,7 @@ Sys module docs.
             source2 = pages_dir / "sys_docs.md"
             source2.write_text(source2_content)
 
-            # Regular markdown file (should be ignored)
+            # Regular markdown file (will be copied as passthrough)
             regular_file = pages_dir / "regular.md"
             regular_file.write_text("# Just regular markdown")
 
@@ -244,15 +247,16 @@ Sys module docs.
                 pages_dir, output_dir, template_dirs=[template_dir]
             )
 
-            assert len(generated) == 2
+            # Now expects 3 files: 2 generated from frontmatter + 1 passthrough
+            assert len(generated) == 3
             filenames = {f.name for f in generated}
-            assert filenames == {"os.md", "sys.md"}
+            assert filenames == {"os.md", "sys.md", "regular.md"}
 
             for output_file in generated:
                 assert output_file.exists()
 
     def test_generate_directory_no_frontmatter_files(self):
-        """Tests error when no frontmatter files found."""
+        """Tests directories with no frontmatter files work (passthrough only)."""
         with TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
 
@@ -266,8 +270,12 @@ Sys module docs.
 
             output_dir = temp_path / "output"
 
-            with pytest.raises(GenerationError, match="No frontmatter files found"):
-                generate_directory(pages_dir, output_dir)
+            # Should not error, should copy passthrough files
+            generated = generate_directory(pages_dir, output_dir)
+
+            assert len(generated) == 1
+            assert (output_dir / "regular.md").exists()
+            assert (output_dir / "regular.md").read_text() == "# Just regular markdown"
 
     def test_generate_directory_nonexistent(self):
         """Tests error when directory doesn't exist."""
@@ -372,3 +380,367 @@ Content.
             # between exists() and is_file() checks would trigger this error.
             # For now, we'll skip this edge case test.
             pass
+
+
+class TestFindAllFiles:
+    """Tests for find_all_files function."""
+
+    def test_find_all_files_success(self):
+        """Tests finding all files in a directory."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create various files
+            (temp_path / "regular.md").write_text("# Regular file")
+            (temp_path / "frontmatter.md").write_text("---\nkey: value\n---\nContent")
+            (temp_path / "_sidebar.md").write_text("# Sidebar")
+            (temp_path / "__pycache__").mkdir()
+            (temp_path / "__pycache__" / "test.pyc").write_text("binary")
+
+            # Create subdirectory with files
+            subdir = temp_path / "subdir"
+            subdir.mkdir()
+            (subdir / "sub.txt").write_text("Sub content")
+            (subdir / ".hidden").write_text("Hidden file")
+
+            files = find_all_files(temp_path)
+
+            assert len(files) == 6
+            filenames = [f.name for f in files]
+            assert "regular.md" in filenames
+            assert "frontmatter.md" in filenames
+            assert "_sidebar.md" in filenames
+            assert "test.pyc" in filenames
+            assert "sub.txt" in filenames
+            assert ".hidden" in filenames
+
+    def test_find_all_files_empty_directory(self):
+        """Tests finding files in empty directory."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            files = find_all_files(temp_path)
+            assert files == []
+
+    def test_find_all_files_nonexistent_directory(self):
+        """Tests error when directory doesn't exist."""
+        with pytest.raises(NotADirectoryError, match="Directory not found"):
+            find_all_files(Path("nonexistent_directory"))
+
+    def test_find_all_files_not_directory(self):
+        """Tests error when path is not a directory."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            file_path = temp_path / "regular_file.txt"
+            file_path.write_text("content")
+
+            with pytest.raises(NotADirectoryError, match="Path is not a directory"):
+                find_all_files(file_path)
+
+
+class TestCategorizeFiles:
+    """Tests for categorize_files function."""
+
+    def test_categorize_mixed_files(self):
+        """Tests categorizing a mix of frontmatter and regular files."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create frontmatter file
+            frontmatter_file = temp_path / "with_frontmatter.md"
+            frontmatter_content = """---
+template: "test.md.jinja2"
+output:
+  - filename: "output.md"
+    griffe_target: "os"
+---
+Content here."""
+            frontmatter_file.write_text(frontmatter_content)
+
+            # Create regular files
+            regular_file = temp_path / "regular.md"
+            regular_file.write_text("# Just markdown")
+
+            sidebar_file = temp_path / "_sidebar.md"
+            sidebar_file.write_text("## Sidebar content")
+
+            files = [frontmatter_file, regular_file, sidebar_file]
+            frontmatter_files, passthrough_files = categorize_files(files)
+
+            assert len(frontmatter_files) == 1
+            assert frontmatter_file in frontmatter_files
+
+            assert len(passthrough_files) == 2
+            assert regular_file in passthrough_files
+            assert sidebar_file in passthrough_files
+
+    def test_categorize_only_frontmatter_files(self):
+        """Tests categorizing only frontmatter files."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create multiple frontmatter files
+            files = []
+            for i in range(3):
+                file_path = temp_path / f"frontmatter_{i}.md"
+                file_content = f"""---
+template: "test.md.jinja2"
+output:
+  - filename: "output_{i}.md"
+    griffe_target: "os"
+---
+Content {i}."""
+                file_path.write_text(file_content)
+                files.append(file_path)
+
+            frontmatter_files, passthrough_files = categorize_files(files)
+
+            assert len(frontmatter_files) == 3
+            assert len(passthrough_files) == 0
+            assert all(f in frontmatter_files for f in files)
+
+    def test_categorize_only_regular_files(self):
+        """Tests categorizing only regular files."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create regular files
+            files = []
+            for i in range(3):
+                file_path = temp_path / f"regular_{i}.md"
+                file_path.write_text(f"# Regular file {i}")
+                files.append(file_path)
+
+            frontmatter_files, passthrough_files = categorize_files(files)
+
+            assert len(frontmatter_files) == 0
+            assert len(passthrough_files) == 3
+            assert all(f in passthrough_files for f in files)
+
+    def test_categorize_empty_list(self):
+        """Tests categorizing empty file list."""
+        frontmatter_files, passthrough_files = categorize_files([])
+        assert len(frontmatter_files) == 0
+        assert len(passthrough_files) == 0
+
+
+class TestCopyFilePassthrough:
+    """Tests for copy_file_passthrough function."""
+
+    def test_copy_file_passthrough_success(self):
+        """Tests successful file passthrough copy."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create source structure
+            source_dir = temp_path / "source"
+            source_dir.mkdir()
+            source_file = source_dir / "test.md"
+            source_content = "# Test content"
+            source_file.write_text(source_content)
+
+            # Set up output directory
+            output_dir = temp_path / "output"
+
+            # Copy the file
+            copied_file = copy_file_passthrough(source_file, source_dir, output_dir)
+
+            # Verify results
+            expected_output = output_dir / "test.md"
+            assert copied_file == expected_output
+            assert copied_file.exists()
+            assert copied_file.read_text() == source_content
+
+    def test_copy_file_passthrough_with_subdirectories(self):
+        """Tests copying file with nested directory structure."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create nested source structure
+            source_dir = temp_path / "source"
+            nested_dir = source_dir / "docs" / "guides"
+            nested_dir.mkdir(parents=True)
+            source_file = nested_dir / "guide.md"
+            source_content = "# Guide content"
+            source_file.write_text(source_content)
+
+            # Set up output directory
+            output_dir = temp_path / "output"
+
+            # Copy the file
+            copied_file = copy_file_passthrough(source_file, source_dir, output_dir)
+
+            # Verify directory structure is preserved
+            expected_output = output_dir / "docs" / "guides" / "guide.md"
+            assert copied_file == expected_output
+            assert copied_file.exists()
+            assert copied_file.read_text() == source_content
+
+            # Verify intermediate directories were created
+            assert (output_dir / "docs").is_dir()
+            assert (output_dir / "docs" / "guides").is_dir()
+
+    def test_copy_file_passthrough_special_names(self):
+        """Tests copying files with special prefixes."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            source_dir = temp_path / "source"
+            source_dir.mkdir()
+            output_dir = temp_path / "output"
+
+            # Test various special filename patterns
+            special_files = [
+                "_sidebar.md",
+                "__init__.py",
+                ".gitignore",
+                ".hidden",
+            ]
+
+            for filename in special_files:
+                source_file = source_dir / filename
+                content = f"Content of {filename}"
+                source_file.write_text(content)
+
+                copied_file = copy_file_passthrough(source_file, source_dir, output_dir)
+
+                expected_output = output_dir / filename
+                assert copied_file == expected_output
+                assert copied_file.exists()
+                assert copied_file.read_text() == content
+
+    def test_copy_file_passthrough_file_outside_source_dir(self):
+        """Tests error when source file is outside source directory."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create directories
+            source_dir = temp_path / "source"
+            source_dir.mkdir()
+            outside_dir = temp_path / "outside"
+            outside_dir.mkdir()
+            output_dir = temp_path / "output"
+
+            # Create file outside source directory
+            outside_file = outside_dir / "outside.md"
+            outside_file.write_text("Outside content")
+
+            with pytest.raises(GenerationError, match="is not within source directory"):
+                copy_file_passthrough(outside_file, source_dir, output_dir)
+
+
+class TestGenerateDirectoryPassthrough:
+    """Tests for generate_directory function with passthrough functionality."""
+
+    def test_generate_directory_mixed_files(self):
+        """Tests directory generation with mixed frontmatter and passthrough files."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create template
+            template_dir = temp_path / "templates"
+            template_dir.mkdir()
+            template_content = "# {{ obj.name }}\n\n{{ custom_vars.test_var }}"
+            template_file = template_dir / "test.md.jinja2"
+            template_file.write_text(template_content)
+
+            # Create source directory with mixed files
+            source_dir = temp_path / "source"
+            source_dir.mkdir()
+
+            # Frontmatter file
+            frontmatter_file = source_dir / "api.md"
+            frontmatter_content = """---
+template: "test.md.jinja2"
+output:
+  - filename: "os_module.md"
+    griffe_target: "os"
+custom_vars:
+  test_var: "API Documentation"
+---
+Source content here."""
+            frontmatter_file.write_text(frontmatter_content)
+
+            # Regular passthrough files
+            (source_dir / "README.md").write_text("# Project README")
+            (source_dir / "_sidebar.md").write_text("## Navigation")
+
+            # Subdirectory with passthrough file
+            subdir = source_dir / "guides"
+            subdir.mkdir()
+            (subdir / "getting-started.md").write_text("# Getting Started")
+
+            # Generate
+            output_dir = temp_path / "output"
+            generated_files = generate_directory(
+                source_dir, output_dir, template_dirs=[template_dir]
+            )
+
+            # Verify results
+            assert len(generated_files) == 4
+
+            # Check generated file (from frontmatter)
+            generated_api = output_dir / "source" / "os_module.md"
+            assert generated_api.exists()
+            content = generated_api.read_text()
+            assert "# os" in content
+            assert "API Documentation" in content
+
+            # Check passthrough files
+            readme = output_dir / "README.md"
+            assert readme.exists()
+            assert readme.read_text() == "# Project README"
+
+            sidebar = output_dir / "_sidebar.md"
+            assert sidebar.exists()
+            assert sidebar.read_text() == "## Navigation"
+
+            guide = output_dir / "guides" / "getting-started.md"
+            assert guide.exists()
+            assert guide.read_text() == "# Getting Started"
+
+    def test_generate_directory_only_passthrough_files(self):
+        """Tests directory generation with only passthrough files (no frontmatter)."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create source directory with only passthrough files
+            source_dir = temp_path / "source"
+            source_dir.mkdir()
+
+            (source_dir / "README.md").write_text("# Project README")
+            (source_dir / "LICENSE").write_text("MIT License")
+            (source_dir / ".gitignore").write_text("*.pyc")
+
+            # Subdirectory
+            subdir = source_dir / "assets"
+            subdir.mkdir()
+            (subdir / "logo.txt").write_text("LOGO")
+
+            # Generate (should not error)
+            output_dir = temp_path / "output"
+            generated_files = generate_directory(source_dir, output_dir)
+
+            # Verify all files were copied
+            assert len(generated_files) == 4
+
+            assert (output_dir / "README.md").exists()
+            assert (output_dir / "LICENSE").exists()
+            assert (output_dir / ".gitignore").exists()
+            assert (output_dir / "assets" / "logo.txt").exists()
+
+            # Verify content
+            assert (output_dir / "README.md").read_text() == "# Project README"
+            assert (output_dir / "LICENSE").read_text() == "MIT License"
+
+    def test_generate_directory_empty_directory(self):
+        """Tests directory generation with empty source directory."""
+        with TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            source_dir = temp_path / "source"
+            source_dir.mkdir()
+            output_dir = temp_path / "output"
+
+            # Should not error with empty directory
+            generated_files = generate_directory(source_dir, output_dir)
+            assert generated_files == []


### PR DESCRIPTION
Allows users to fully define their documentation in `source/`, even if it's not being built by griffonner.

Closes #20 